### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ npm start
 
 After that, open `127.0.0.1:9000` with your browser. I recommend you use chrome latest for the best experience.
 
-###License
+### License
 
 MIT


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
